### PR TITLE
CDO processing

### DIFF
--- a/process__cdo.R
+++ b/process__cdo.R
@@ -1,0 +1,11 @@
+## Script to open and process heterotrophic respiration data from MIMICS, CORPSE, and CASA-CNP
+## Created July 13, 2020 | Stephanie Pennington 
+
+# We need to calculate an average Rh for each model output, this should give us
+# One number for each year in the dataset, i.e. 11 numbers for each grid cell
+cat("Running cdo...")
+
+system("cdo -yearmean data/Wieder/mimics_pool_flux_2000-2010_daily.nc data/Wieder/mimics_pool_flux_2000-2010_mean.nc")
+system("cdo -yearmean data/Wieder/corpse_pool_flux_2000-2010_daily.nc data/Wieder/corpse_pool_flux_2000-2010_mean.nc")
+system("cdo -yearmean data/Wieder/casaclm_pool_flux_2000-2010_daily.nc data/Wieder/casaclm_pool_flux_2000-2010_mean.nc")
+

--- a/process__cdo.R
+++ b/process__cdo.R
@@ -5,6 +5,8 @@
 # One number for each year in the dataset, i.e. 11 numbers for each grid cell
 cat("Running cdo...")
 
+# NOTE: This assumes there is a folder called `/data/Wieder` in /landmodels with the raw files
+
 system("cdo -yearmean data/Wieder/mimics_pool_flux_2000-2010_daily.nc data/Wieder/mimics_pool_flux_2000-2010_mean.nc")
 system("cdo -yearmean data/Wieder/corpse_pool_flux_2000-2010_daily.nc data/Wieder/corpse_pool_flux_2000-2010_mean.nc")
 system("cdo -yearmean data/Wieder/casaclm_pool_flux_2000-2010_daily.nc data/Wieder/casaclm_pool_flux_2000-2010_mean.nc")


### PR DESCRIPTION
File outputs for MIMICS, CORPSE, and CASAclm were processed in CDO using the operator `-yearmean`. This produces 1 value for each variable, representing the mean.

The new R script `process_cdo.R` calls CDO on the local computer and processes each file. Note this requires a `data/Wieder` folder with the raw data, and CDO installed on the computer.